### PR TITLE
fix homepage styling issue

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -102,5 +102,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/views/pages/home/home.component.scss
+++ b/src/app/views/pages/home/home.component.scss
@@ -1,5 +1,6 @@
 @use '/src/styles.scss';
 
+
 .bg-image {
     position: absolute;
     width: 100%;
@@ -51,10 +52,12 @@
 
     .page-thumbnail-wrapper {
         width: 100%;
-        height: 50%;
+        height: 80%;
         display: flex;
         flex-direction: row;
         justify-content: center;
+        align-items: center;
+
 
         .page-thumbnail-container {
             position: absolute;
@@ -65,22 +68,23 @@
             flex-wrap: nowrap;
             width: 80%;
             min-width: 1300px;
-            
+
             .page-thumbnail {
-                width: 250px;
-                height: 500px;
+                width:15vw;
+                min-width: 200px;
+                aspect-ratio: 1 / 2;
                 display: flex;
                 flex-direction: column;
                 padding: 50px 25px;
-                
+
                 background-size: cover;
-    
+
                 cursor: pointer;
-    
+
                 .spacer {
                     flex-grow: 1;
                 }
-        
+
                 .title {
                     font-size: xx-large;
                 }
@@ -93,3 +97,12 @@
     }
 
 }
+
+	/* fallback */
+	@supports not (aspect-ratio: 1 / 2) {
+    .page-thumbnail {
+		padding-top: 100%;
+		height: 0;
+		position: relative;
+  }
+	}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -6,6 +6,7 @@ $app-theme: m3-theme.$dark-theme;
 $app-theme-color-primary: mat.get-theme-color($app-theme, primary);
 $app-theme-color-bg: mat.get-theme-color($app-theme, 'background');
 
+
 html {
     @include mat.all-component-themes($app-theme);
 


### PR DESCRIPTION
set thumbnail-wrapper height to 80% (fixes the overflow issue)
add aspect ratio to thumbnail container styling + fallback,
thumbnail container: changed the width to width:15vw and min-width:200px so it scales correctly in big screen, and do not go lower in small screen
thumbnail wrapper: used align items center because changing the size also changed its alignment


more info here  (b ᵔ▽ᵔ)b 
https://discord.com/channels/1263773356461654129/1264011589208506388/1275465313366052936